### PR TITLE
Fixed bug : when token not equal a payement

### DIFF
--- a/paydunya/checkout/checkout_invoice.php
+++ b/paydunya/checkout/checkout_invoice.php
@@ -140,7 +140,7 @@ class Paydunya_Checkout_Invoice extends Paydunya_Checkout {
     }
 
     $result = Paydunya_Utilities::httpGetRequest(Paydunya_Setup::getCheckoutConfirmUrl().$token);
-    if(count($result) > 0) {
+    if(count($result) > 0 && array_key_exists('status', $result)) {
       switch ($result['status']) {
         case 'completed':
           $this->status = $result['status'];


### PR DESCRIPTION
When token return not found payement; in return endpoint it's not present key status